### PR TITLE
use std::sync::RwLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,9 @@ is-it-maintained-open-issues = { repository = "leo60228/broadcaster" }
 maintenance = { status = "experimental"}
 
 [features]
-default = ["default-channels"]
+default = ["default-channels", "default-sync"]
 default-channels = ["futures-channel-preview"]
+default-sync = ["parking_lot"]
 
 [dependencies]
 futures-core-preview = "0.3.0-alpha.18"
@@ -26,6 +27,7 @@ futures-sink-preview = "0.3.0-alpha.18"
 futures-util-preview = { version = "0.3.0-alpha.18", features = ["sink"] }
 futures-channel-preview = { version = "0.3.0-alpha.18", optional = true, features = ["sink"] }
 slab = "0.4.2"
+parking_lot = { version = "0.9.0", optional = true }
 
 [dev-dependencies]
 futures-executor-preview = "0.3.0-alpha.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ is-it-maintained-open-issues = { repository = "leo60228/broadcaster" }
 maintenance = { status = "experimental"}
 
 [features]
-default = ["default-channels", "default-sync"]
+default = ["default-channels", "parking-lot"]
 default-channels = ["futures-channel-preview"]
-default-sync = ["parking_lot"]
+parking-lot = ["parking_lot"]
 
 [dependencies]
 futures-core-preview = "0.3.0-alpha.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ futures-sink-preview = "0.3.0-alpha.18"
 futures-util-preview = { version = "0.3.0-alpha.18", features = ["sink"] }
 futures-channel-preview = { version = "0.3.0-alpha.18", optional = true, features = ["sink"] }
 slab = "0.4.2"
-parking_lot = "0.9.0"
 
 [dev-dependencies]
 futures-executor-preview = "0.3.0-alpha.18"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,10 +26,15 @@ use futures_sink::Sink;
 use futures_util::sink::SinkExt;
 use futures_util::stream::StreamExt;
 use futures_util::try_future::try_join_all;
-use std::sync::RwLock;
 use slab::Slab;
 use std::fmt::{self, Debug};
 use std::sync::Arc;
+
+#[cfg(not(feature = "default-channels"))]
+use std::sync::RwLock;
+
+#[cfg(feature = "default-channels")]
+use parking_lot::RwLock;
 
 #[cfg(feature = "default-channels")]
 use futures_channel::mpsc::*;
@@ -86,6 +91,10 @@ impl<T: Send + Clone> BroadcastChannel<T, Sender<T>, Receiver<T>> {
 
     /// Try sending a value on a bounded channel. Requires the `default-channels` feature.
     pub fn try_send(&self, item: &T) -> Result<(), TrySendError<T>> {
+        #[cfg(feature = "default-sync")]
+        let mut senders: Slab<Sender<T>> = Slab::clone(&*self.senders.read());
+
+        #[cfg(not(feature = "default-sync"))]
         let mut senders: Slab<Sender<T>> = Slab::clone(&*self.senders.read().unwrap());
 
         senders
@@ -120,6 +129,10 @@ where
     /// desired behavior, you must handle it yourself.
     pub async fn send(&self, item: &T) -> Result<(), S::Error> {
         // can't be split up because of how async/await works
+        #[cfg(feature = "default-sync")]
+        let mut senders: Slab<S> = Slab::clone(&*self.senders.read());
+
+        #[cfg(not(feature = "default-sync"))]
         let mut senders: Slab<S> = Slab::clone(&*self.senders.read().unwrap());
 
         try_join_all(senders.iter_mut().map(|(_, s)| s.send(item.clone()))).await?;
@@ -140,6 +153,10 @@ where
 {
     fn clone(&self) -> Self {
         let (tx, rx) = (self.ctor)();
+        #[cfg(feature = "default-sync")]
+        let sender_key = self.senders.write().insert(tx);
+
+        #[cfg(not(feature = "default-sync"))]
         let sender_key = self.senders.write().unwrap().insert(tx);
 
         Self {
@@ -158,6 +175,10 @@ where
     R: Unpin + Stream<Item = T>,
 {
     fn drop(&mut self) {
+        #[cfg(feature = "default-sync")]
+        self.senders.write().remove(self.sender_key);
+
+        #[cfg(not(feature = "default-sync"))]
         self.senders.write().unwrap().remove(self.sender_key);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ use futures_sink::Sink;
 use futures_util::sink::SinkExt;
 use futures_util::stream::StreamExt;
 use futures_util::try_future::try_join_all;
-use parking_lot::RwLock;
+use std::sync::RwLock;
 use slab::Slab;
 use std::fmt::{self, Debug};
 use std::sync::Arc;
@@ -86,7 +86,7 @@ impl<T: Send + Clone> BroadcastChannel<T, Sender<T>, Receiver<T>> {
 
     /// Try sending a value on a bounded channel. Requires the `default-channels` feature.
     pub fn try_send(&self, item: &T) -> Result<(), TrySendError<T>> {
-        let mut senders: Slab<Sender<T>> = Slab::clone(&*self.senders.read());
+        let mut senders: Slab<Sender<T>> = Slab::clone(&*self.senders.read().unwrap());
 
         senders
             .iter_mut()
@@ -120,7 +120,7 @@ where
     /// desired behavior, you must handle it yourself.
     pub async fn send(&self, item: &T) -> Result<(), S::Error> {
         // can't be split up because of how async/await works
-        let mut senders: Slab<S> = Slab::clone(&*self.senders.read());
+        let mut senders: Slab<S> = Slab::clone(&*self.senders.read().unwrap());
 
         try_join_all(senders.iter_mut().map(|(_, s)| s.send(item.clone()))).await?;
         Ok(())
@@ -140,7 +140,7 @@ where
 {
     fn clone(&self) -> Self {
         let (tx, rx) = (self.ctor)();
-        let sender_key = self.senders.write().insert(tx);
+        let sender_key = self.senders.write().unwrap().insert(tx);
 
         Self {
             senders: self.senders.clone(),
@@ -158,7 +158,7 @@ where
     R: Unpin + Stream<Item = T>,
 {
     fn drop(&mut self) {
-        self.senders.write().remove(self.sender_key);
+        self.senders.write().unwrap().remove(self.sender_key);
     }
 }
 


### PR DESCRIPTION
Replaces `parking_lot::RwLock` with `std::sync::RwLock`, removing about 50% of dependencies in tree. Furthermore, `parking_lot`'s Mutex / RwLock APIs are set to become part of `std` and continued to be optimized there, so this sets us up to be somewhat future-proof. Thanks!

## Proposed

![2019-09-26-111127_1920x1080](https://user-images.githubusercontent.com/2467194/65675312-40c16d80-e04e-11e9-8a05-f4876616994f.png)


## Current

![2019-09-26-110930_1920x1080](https://user-images.githubusercontent.com/2467194/65675321-43bc5e00-e04e-11e9-8fd0-74986fd1a889.png)
