### PR TITLE
WIP/Feedback wanted: Sink and Stream implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,16 @@ broadcasting items. This means that any item sent will be received by every rece
 the first to check (like most mpmc streams). As an example:
 ```rust
 use broadcaster::BroadcastChannel;
+use futures_util::StreamExt;
 
 let mut chan = BroadcastChannel::new();
 chan.send(&5i32).await?;
-assert_eq!(chan.recv().await, Some(5));
+assert_eq!(chan.next().await, Some(5));
 
 let mut chan2 = chan.clone();
 chan2.send(&6i32).await?;
-assert_eq!(chan.recv().await, Some(6));
-assert_eq!(chan2.recv().await, Some(6));
+assert_eq!(chan.next().await, Some(6));
+assert_eq!(chan2.next().await, Some(6));
 ```
 
 <!-- cargo-sync-readme end -->

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! # }).unwrap();
 //! ```
 
-use futures_core::{future::*, stream::*, Poll};
+use futures_core::{future::*, stream::*, task::Poll};
 use futures_sink::Sink;
 use futures_util::sink::SinkExt;
 use futures_util::stream::StreamExt;


### PR DESCRIPTION
So as mentioned in #3 I've finally gotten to implementing Sink as well as Stream. This implementation works, however there are some open questions remaining:

* There's a bit of a disconnect between the requirements on the recv/send methods and the implementations for Sink/Stream. The implementations for Sink and Stream usually require a mutable reference, but that's not actually necessary for this channel because it internally clones the senders anyways. Maybe I'll try implementing the traits for &BroadcastChannel instead of BroadcastChannel?
* With the separate methods on Sink (poll_ready, start_send, poll_flush), I wonder what happens if a new clone of the channel is made anywhere between those calls. Need to write a test or two here I think.
* Related to the previous concern, I think it may be advisable to implement this in a way where the cloning doesn't happen on _every_ poll call, also for performance reasons.

Finally, an async port of crossbeam's channels just became available in the async-std project! It's MPMC, but _not_ a broadcast channel. Still may be worth seeing how that implementation works and if there are any good ideas to copy there.